### PR TITLE
query-string Ensure name doesn't have to be first parameter

### DIFF
--- a/static/scripts/CustomTextHandler.js
+++ b/static/scripts/CustomTextHandler.js
@@ -1,7 +1,7 @@
 class CustomTextHandler {
     receiveParameters() {
         const url = window.location.href;
-        const regexPattern = /(?<=\?name=)[a-z0-9?!.,#()\%\@\:\;\/\-]+/i;
+        const regexPattern = /(?<=\??name=)[a-z0-9?!.,#()\%\@\:\;\/\-]+/i;
         const match = url.match(regexPattern);
 
         if (match !== null) {


### PR DESCRIPTION
A question mark has been added to the regex for the custom text handler to indicate that the name doesn't have to come first in the query strings.